### PR TITLE
enhanced autoconfiguration & updated jackson

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,12 +36,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.9.3</version>
+            <version>2.9.8</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jsr310</artifactId>
-            <version>2.9.3</version>
+            <version>2.9.8</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/ua/ardas/redis/client/RedisClientAutoConfiguration.java
+++ b/src/main/java/ua/ardas/redis/client/RedisClientAutoConfiguration.java
@@ -1,12 +1,17 @@
 package ua.ardas.redis.client;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.boot.autoconfigure.AutoConfigureBefore;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnNotWebApplication;
+import org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
 
 @Configuration
+@AutoConfigureBefore(RedisAutoConfiguration.class)
 @EnableConfigurationProperties(RedisClientProperties.class)
 public class RedisClientAutoConfiguration {
 
@@ -14,5 +19,13 @@ public class RedisClientAutoConfiguration {
     @ConditionalOnNotWebApplication
     public ObjectMapper objectMapper() {
         return new ObjectMapper();
+    }
+
+    @Bean("redisClientTemplate")
+    @ConditionalOnClass({ObjectMapper.class})
+    public RedisClientTemplate redisClientTemplate(RedisConnectionFactory connectionFactory,
+                                                   RedisClientProperties properties,
+                                                   ObjectMapper objectMapper) {
+        return new RedisClientTemplate(connectionFactory, properties, objectMapper);
     }
 }

--- a/src/main/java/ua/ardas/redis/client/RedisClientTemplate.java
+++ b/src/main/java/ua/ardas/redis/client/RedisClientTemplate.java
@@ -6,23 +6,17 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.lettuce.core.RedisCommandInterruptedException;
 import lombok.extern.apachecommons.CommonsLog;
 import org.apache.commons.lang3.StringUtils;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.dao.QueryTimeoutException;
 import org.springframework.data.redis.RedisSystemException;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.core.StringRedisTemplate;
-import org.springframework.stereotype.Component;
 import ua.ardas.redis.client.dto.RedisRequest;
 import ua.ardas.redis.client.dto.RedisResponse;
 import ua.ardas.redis.client.dto.ResponseKey;
 
 import java.io.Closeable;
 import java.io.IOException;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Optional;
-import java.util.UUID;
+import java.util.*;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
@@ -31,8 +25,6 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 
 @CommonsLog
-@Component("redisClientTemplate")
-@ConditionalOnClass({ObjectMapper.class})
 public class RedisClientTemplate extends StringRedisTemplate implements Closeable {
 
     private static final String REQUEST_TEMPLATE = "%s-request";

--- a/src/main/resources/META-INF/spring.factories
+++ b/src/main/resources/META-INF/spring.factories
@@ -1,1 +1,1 @@
-org.springframework.boot.autoconfigure.EnableAutoConfiguration=ua.ardas.redis.client.RedisClientAutoConfiguration,ua.ardas.redis.client.RedisClientTemplate
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=ua.ardas.redis.client.RedisClientAutoConfiguration


### PR DESCRIPTION
Теперь автоконфигурация применяется перед RedisAutoConfiguration (spring starter).

_Какую проблему решает?_ 
Раньше в spring-контейнер первым попадал StringRedisTemplate, а после него RedisClientTemplate. Таким образом получалось 2 компонента с одним base-классом, что приводило к UnsatisfiedDependencyException в некоторых случаях. 

_Как боролись раньше?_ 
На разных проектах использовалась @Import для импорта RedisClientTemplate, что обеспечивало его попадание в контейнер до конфигурации стартера. А так как StringRedisTemplate помечен как @ConditionalOnMissingBean, то компонент не создавался, проблема пропадала.
Такой подход решения проблемы нарушает инверсию контроля модулей, что предоставляет spring.factories.